### PR TITLE
Set sphere resolution default

### DIFF
--- a/Engine/src/argument_parser.cpp
+++ b/Engine/src/argument_parser.cpp
@@ -10,6 +10,8 @@ const int DEFAULT_SPHERE_RESOLUTION = 25;
 }
 
 ArgumentParser::ArgumentParser(int argc, char** argv)
+:mImagePath()
+,mSphereResolution(DEFAULT_SPHERE_RESOLUTION)
 {
     if(argc < 2)
     {


### PR DESCRIPTION
Fix a bug when leaving `sphere_resolution` argument empty that resulted in a sphere with 0 vertices.