### PR TITLE
Add support for full spherical harmonics basis

### DIFF
--- a/Engine/include/sh_field.h
+++ b/Engine/include/sh_field.h
@@ -105,6 +105,7 @@ private:
         unsigned int MaxOrder;
         float SH0threshold;
         float Scaling;
+        unsigned int NbCoeffs;
     };
 
     /// Struct containing the voxel grid attributes for the GPU.
@@ -163,7 +164,7 @@ private:
     std::mutex mMutex;
 
     /// Sphere used for SH projection.
-    Primitive::Sphere mSphere;
+    std::shared_ptr<Primitive::Sphere> mSphere;
 
     /// Maximum number of spheres rendered.
     uint mNbSpheres;

--- a/Engine/include/sphere.h
+++ b/Engine/include/sphere.h
@@ -78,7 +78,7 @@ private:
     std::vector<float> mSphHarmFunc;
 
     /// SH basis in use.
-    std::shared_ptr<Math::SH::RealSymDescoteauxBasis> mSHBasis;
+    std::shared_ptr<SH::DescoteauxBasis> mSHBasis;
 
     /// Resolution of sphere.
     unsigned int mResolution;

--- a/Engine/include/sphere.h
+++ b/Engine/include/sphere.h
@@ -19,10 +19,6 @@ public:
 
     /// Constructor.
     /// \param[in] resolution Resolution of the sphere.
-    Sphere(unsigned int resolution);
-
-    /// Constructor.
-    /// \param[in] resolution Resolution of the sphere.
     /// \param[in] nbSHCoeffs Number of spherical harmonics coefficients.
     Sphere(unsigned int resolution, unsigned int nbSHCoeffs);
 
@@ -49,7 +45,12 @@ public:
 
     /// Get the maximum SH order.
     /// \return The maximum SH order for the basis.
-    inline unsigned int GetMaxSHOrder() const {return mSHBasis.GetMaxOrder(); };
+    inline unsigned int GetMaxSHOrder() const {return mSHBasis->GetMaxOrder(); };
+
+    /// Get all SH orders.
+    /// \return A vector where the ith position contains the SH order
+    ///         corresponding to the SH function at position i.
+    inline std::vector<float> GetOrdersList() const { return mSHBasis->GetOrderList(); };
 
 private:
     /// Generate the sphere mesh.
@@ -77,7 +78,7 @@ private:
     std::vector<float> mSphHarmFunc;
 
     /// SH basis in use.
-    Math::SH::RealSymDescoteauxBasis mSHBasis;
+    std::shared_ptr<Math::SH::RealSymDescoteauxBasis> mSHBasis;
 
     /// Resolution of sphere.
     unsigned int mResolution;

--- a/Engine/include/spherical_harmonic.h
+++ b/Engine/include/spherical_harmonic.h
@@ -12,27 +12,6 @@ namespace Math
 {
 namespace SH
 {
-namespace Utils
-{
-static inline unsigned int OrderFromNbCoeffs(unsigned int nbCoeffs)
-{
-    return static_cast<unsigned int>(-3.0 + sqrt(9.0 - 4.0 * (2.0 - 2.0 * nbCoeffs)))/2;
-}
-
-static std::vector<float> GetOrdersList(unsigned int maxOrder)
-{
-    std::vector<float> orders;
-    for(int l = 0; l <= maxOrder; l += 2)
-    {
-        for(int m = -l; m <= l; ++m)
-        {
-            orders.push_back((float)l);
-        }
-    }
-    return orders;
-}
-} // namespace Utils
-
 /// \brief Implementation of DIPY legacy real symmetric Descoteaux07 basis.
 ///
 /// See https://dipy.org/documentation/1.4.1./theory/sh_basis/ for more details.
@@ -43,8 +22,9 @@ public:
     RealSymDescoteauxBasis();
 
     /// Constructor.
-    /// \param[in] maxOrder Maximum SH order for reconstruction.
-    RealSymDescoteauxBasis(unsigned int maxOrder);
+    /// \param[in] nbCoeffs Number of SH coefficients and functions
+    ///                     for reconstruction.
+    RealSymDescoteauxBasis(unsigned int nbCoeffs);
 
     /// Destructor.
     ~RealSymDescoteauxBasis() = default;
@@ -57,10 +37,28 @@ public:
     /// \return SH basis evaluated for l, m, theta, phi.
     float at(unsigned int l, int m, float theta, float phi) const;
 
+    /// Evaluate SH basis for l, m, theta, phi.
+    /// \param[in] theta Inclination angle in radians.
+    /// \param[in] phi Azimuth angle in radians.
+    /// \return SH basis evaluated for l, m, theta, phi.
+    std::vector<float> at(float theta, float phi) const;
+
     /// Get the maximum SH order.
     /// \return Maximum SH order.
     inline unsigned int GetMaxOrder() const { return mMaxOrder; };
+
+    /// Get the list of SH orders.
+    /// \return A vector containing all SH orders, repeated.
+    std::vector<float> GetOrderList() const;
+
 private:
+    /// Get the maximum order from the number of SH coefficients.
+    /// Also detects if the basis is full if fullBasis is supplied.
+    /// \param[in] nbCoeffs Number of SH coefficients and functions.
+    /// \param[out] fullBasis When supplied, contains true if the basis is full.
+    /// \return The maximum order from the number of SH coefficients.
+    unsigned int getOrderFromNbCoeffs(unsigned int nbCoeffs, bool* fullBasis=nullptr) const;
+
     /// Get the flattened index for order l and degree m.
     /// \param[in] l SH order (0 <= l <= mMaxOrder).
     /// \param[in] m SH degree (-l <= m <= l).
@@ -90,6 +88,9 @@ private:
 
     /// Maximum SH order.
     uint mMaxOrder;
+
+    /// Full basis flag. When true, basis includes odd order SH functions.
+    bool mFullBasis;
 };
 } // namespace SH
 } // namespace Math

--- a/Engine/include/spherical_harmonic.h
+++ b/Engine/include/spherical_harmonic.h
@@ -8,26 +8,24 @@
 
 namespace Slicer
 {
-namespace Math
-{
 namespace SH
 {
-/// \brief Implementation of DIPY legacy real symmetric Descoteaux07 basis.
+/// \brief Implementation of DIPY legacy real Descoteaux07 basis.
 ///
 /// See https://dipy.org/documentation/1.4.1./theory/sh_basis/ for more details.
-class RealSymDescoteauxBasis
+class DescoteauxBasis
 {
 public:
     /// Default constructor.
-    RealSymDescoteauxBasis();
+    DescoteauxBasis();
 
     /// Constructor.
     /// \param[in] nbCoeffs Number of SH coefficients and functions
     ///                     for reconstruction.
-    RealSymDescoteauxBasis(unsigned int nbCoeffs);
+    DescoteauxBasis(unsigned int nbCoeffs);
 
     /// Destructor.
-    ~RealSymDescoteauxBasis() = default;
+    ~DescoteauxBasis() = default;
 
     /// Evaluate SH basis for l, m, theta, phi.
     /// \param[in] l SH function order (0 <= l <= mMaxOrder).
@@ -93,5 +91,4 @@ private:
     bool mFullBasis;
 };
 } // namespace SH
-} // namespace Math
 } // namespace Slicer

--- a/Engine/include/spherical_harmonic.h
+++ b/Engine/include/spherical_harmonic.h
@@ -53,9 +53,9 @@ private:
     /// Get the maximum order from the number of SH coefficients.
     /// Also detects if the basis is full if fullBasis is supplied.
     /// \param[in] nbCoeffs Number of SH coefficients and functions.
-    /// \param[out] fullBasis When supplied, contains true if the basis is full.
+    /// \param[out] fullBasis When not nullptr, contains true if the basis is full.
     /// \return The maximum order from the number of SH coefficients.
-    unsigned int getOrderFromNbCoeffs(unsigned int nbCoeffs, bool* fullBasis=nullptr) const;
+    unsigned int getOrderFromNbCoeffs(unsigned int nbCoeffs, bool* fullBasis) const;
 
     /// Get the flattened index for order l and degree m.
     /// \param[in] l SH order (0 <= l <= mMaxOrder).

--- a/Engine/shaders/compute.glsl
+++ b/Engine/shaders/compute.glsl
@@ -39,6 +39,7 @@ layout(std430, binding=7) buffer sphereInfoBuffer
     uint maxOrder;
     float sh0Threshold;
     float scaling;
+    uint nbCoeffs;
 };
 
 layout(std430, binding=8) buffer gridInfoBuffer
@@ -56,22 +57,17 @@ layout(std430, binding=11) buffer ordersBuffer
 const float FLOAT_EPS = 1e-4;
 const float PI = 3.14159265358979323;
 
-uint nbCoeffsFromOrder(uint order)
-{
-    return (maxOrder + 2) * (maxOrder + 1) / 2;
-}
-
 float evaluateSH(uint voxID, uint sphVertID)
 {
     float ret = 0.0f;
     float sum = 0.0f;
     float rmax = 0.0f;
-    for(int i = 0; i < nbCoeffsFromOrder(maxOrder); ++i)
+    for(int i = 0; i < nbCoeffs; ++i)
     {
-        sum += abs(shCoeffs[voxID * nbCoeffsFromOrder(maxOrder) + i]);
-        ret += shCoeffs[voxID * nbCoeffsFromOrder(maxOrder) + i]
-                * shFuncs[sphVertID * nbCoeffsFromOrder(maxOrder) + i];
-        rmax += (2.0f * L[i] + 1.0f) / 4.0f / PI * pow(shCoeffs[voxID * nbCoeffsFromOrder(maxOrder) + i], 2);
+        sum += abs(shCoeffs[voxID * nbCoeffs + i]);
+        ret += shCoeffs[voxID * nbCoeffs + i]
+                * shFuncs[sphVertID * nbCoeffs + i];
+        rmax += (2.0f * L[i] + 1.0f) / 4.0f / PI * pow(shCoeffs[voxID * nbCoeffs + i], 2);
     }
     if(sum > 0.0)
     {
@@ -188,7 +184,7 @@ void main()
 
     const uint voxID = convertInvocationIDToVoxID(invocationID);
 
-    bool isVisible = shCoeffs[voxID * nbCoeffsFromOrder(maxOrder)] > 0.0f;
+    bool isVisible = shCoeffs[voxID * nbCoeffs] > 0.0f;
 
     scaleSphere(voxID, firstVertID, isVisible);
     if(isVisible)

--- a/Engine/shaders/triangle.vert
+++ b/Engine/shaders/triangle.vert
@@ -28,6 +28,7 @@ layout(std430, binding=7) buffer sphereInfoBuffer
     uint maxOrder;
     float sh0Threshold;
     float scaling;
+    uint nbCoeffs;
 };
 
 layout(std430, binding=8) buffer gridInfoBuffer
@@ -57,11 +58,6 @@ out vec3 v_color;
 out vec4 v_normal;
 out vec4 v_eye;
 out float v_isVisible;
-
-uint nbCoeffsFromOrder(uint order)
-{
-    return (maxOrder + 2) * (maxOrder + 1) / 2;
-}
 
 ivec3 convertInvocationIDToIndex3D(uint invocationID)
 {
@@ -94,7 +90,7 @@ void main()
 {
     const ivec3 index3d = convertInvocationIDToIndex3D(gl_DrawID);
     const uint voxID = convertIndex3DToVoxID(index3d.x, index3d.y, index3d.z);
-    bool isVisible = shCoeffs[voxID * nbCoeffsFromOrder(maxOrder)] > sh0Threshold;
+    bool isVisible = shCoeffs[voxID * nbCoeffs] > sh0Threshold;
 
     mat4 trMat;
     trMat[0][0] = scaling;

--- a/Engine/src/sh_field.cpp
+++ b/Engine/src/sh_field.cpp
@@ -21,6 +21,7 @@ SHField::SHField(const std::shared_ptr<ApplicationState>& state,
 ,mSphereInfoData()
 ,mAllSpheresNormalsData()
 ,mIndirectCmd()
+,mSphere(nullptr)
 {
     initializeMembers();
     resetCS(std::shared_ptr<CoordinateSystem>(new CoordinateSystem(glm::mat4(1.0f), parent)));
@@ -90,8 +91,8 @@ void SHField::initializeMembers()
     mNbSpheres = image.dims().x * image.dims().y  // Z-slice
                + image.dims().x * image.dims().z  // Y-slice
                + image.dims().y * image.dims().z; // X-slice
-    mSphere = Primitive::Sphere(mState->Sphere.Resolution.Get(),
-                                image.dims().w);
+    mSphere.reset(new Primitive::Sphere(mState->Sphere.Resolution.Get(),
+                                        image.dims().w));
 
     std::thread initVoxThread(&SHField::copySHCoefficientsFromImage, this);
     std::thread initSpheresThread(&SHField::initializeDrawCommand, this);
@@ -131,8 +132,8 @@ void SHField::initializeDrawCommand()
     sphereLoopTimer.Start();
 
     const auto& image = mState->FODFImage.Get();
-    const auto numIndices = mSphere.getIndices().size();
-    const auto numVertices = mSphere.getPoints().size();
+    const auto numIndices = mSphere->getIndices().size();
+    const auto numVertices = mSphere->getPoints().size();
 
     // safety when allocating shared memory
     mMutex.lock();
@@ -144,7 +145,7 @@ void SHField::initializeDrawCommand()
     for(uint i = 0; i < mNbSpheres; ++i)
     {
         // Add sphere faces
-        for(const uint& idx: mSphere.getIndices())
+        for(const uint& idx: mSphere->getIndices())
         {
             mIndices.push_back(idx);
         }
@@ -164,17 +165,18 @@ void SHField::initializeDrawCommand()
 void SHField::initializeGPUData()
 {
     // temporary zero-filled array for all spheres vertices and normals
-    std::vector<glm::vec4> allVertices(mNbSpheres * mSphere.getPoints().size());
-    std::vector<float> allRadiis(mNbSpheres * mSphere.getPoints().size());
-    std::vector<float> allOrders = Math::SH::Utils::GetOrdersList(mSphere.GetMaxSHOrder());
+    std::vector<glm::vec4> allVertices(mNbSpheres * mSphere->getPoints().size());
+    std::vector<float> allRadiis(mNbSpheres * mSphere->getPoints().size());
+    std::vector<float> allOrders = mSphere->GetOrdersList();
 
     SphereData sphereData;
-    sphereData.NumVertices = mSphere.getPoints().size();
-    sphereData.NumIndices = mSphere.getIndices().size();
+    sphereData.NumVertices = mSphere->getPoints().size();
+    sphereData.NumIndices = mSphere->getIndices().size();
     sphereData.IsNormalized = mState->Sphere.IsNormalized.Get();
-    sphereData.MaxOrder = mSphere.GetMaxSHOrder();
+    sphereData.MaxOrder = mSphere->GetMaxSHOrder();
     sphereData.SH0threshold = mState->Sphere.SH0Threshold.Get();
     sphereData.Scaling = mState->Sphere.Scaling.Get();
+    sphereData.NbCoeffs = mState->FODFImage.Get().dims().w;
 
     GridData gridData;
     gridData.IsSliceDirty = glm::ivec4(1, 1, 1, 0);
@@ -187,14 +189,14 @@ void SHField::initializeGPUData()
                                      sizeof(float) * allRadiis.size());
     mSphHarmCoeffsData = GPU::ShaderData(mSphHarmCoeffs.data(), GPU::Binding::shCoeffs,
                                          sizeof(float)* mSphHarmCoeffs.size());
-    mSphHarmFuncsData = GPU::ShaderData(mSphere.getSHFuncs().data(), GPU::Binding::shFunctions,
-                                        sizeof(float) * mSphere.getSHFuncs().size());
+    mSphHarmFuncsData = GPU::ShaderData(mSphere->getSHFuncs().data(), GPU::Binding::shFunctions,
+                                        sizeof(float) * mSphere->getSHFuncs().size());
     mAllOrdersData = GPU::ShaderData(allOrders.data(), GPU::Binding::allOrders,
                                      sizeof(float) * allOrders.size());
-    mSphereVerticesData = GPU::ShaderData(mSphere.getPoints().data(), GPU::Binding::sphereVertices,
-                                          sizeof(glm::vec4) * mSphere.getPoints().size());
-    mSphereIndicesData = GPU::ShaderData(mSphere.getIndices().data(), GPU::Binding::sphereIndices,
-                                         sizeof(uint) * mSphere.getIndices().size());
+    mSphereVerticesData = GPU::ShaderData(mSphere->getPoints().data(), GPU::Binding::sphereVertices,
+                                          sizeof(glm::vec4) * mSphere->getPoints().size());
+    mSphereIndicesData = GPU::ShaderData(mSphere->getIndices().data(), GPU::Binding::sphereIndices,
+                                         sizeof(uint) * mSphere->getIndices().size());
     mSphereInfoData = GPU::ShaderData(&sphereData, GPU::Binding::sphereInfo,
                                       sizeof(SphereData));
     mGridInfoData = GPU::ShaderData(&gridData, GPU::Binding::gridInfo,

--- a/Engine/src/sphere.cpp
+++ b/Engine/src/sphere.cpp
@@ -17,7 +17,7 @@ Sphere::Sphere()
 ,mSHBasis(nullptr)
 ,mSphHarmFunc()
 {
-    mSHBasis.reset(new Math::SH::RealSymDescoteauxBasis(DEFAULT_NB_COEFFS));
+    mSHBasis.reset(new SH::DescoteauxBasis(DEFAULT_NB_COEFFS));
     genUnitSphere();
 }
 
@@ -29,7 +29,7 @@ Sphere::Sphere(unsigned int resolution,
 ,mSHBasis()
 ,mSphHarmFunc()
 {
-    mSHBasis.reset(new Math::SH::RealSymDescoteauxBasis(nbSHCoeffs));
+    mSHBasis.reset(new SH::DescoteauxBasis(nbSHCoeffs));
     genUnitSphere();
 }
 

--- a/Engine/src/sphere.cpp
+++ b/Engine/src/sphere.cpp
@@ -2,7 +2,8 @@
 
 namespace
 {
-const uint DEFAULT_MAX_SH_ORDER = 8;
+const uint DEFAULT_NB_COEFFS = 45;
+const uint DEFAULT_RESOLUTION = 20;
 }
 
 namespace Slicer
@@ -10,22 +11,13 @@ namespace Slicer
 namespace Primitive
 {
 Sphere::Sphere()
-:mResolution(10)
+:mResolution(DEFAULT_RESOLUTION)
 ,mIndices()
 ,mPoints()
-,mSHBasis(DEFAULT_MAX_SH_ORDER)
+,mSHBasis(nullptr)
 ,mSphHarmFunc()
 {
-    genUnitSphere();
-}
-
-Sphere::Sphere(unsigned int resolution)
-:mResolution(resolution)
-,mIndices()
-,mPoints()
-,mSHBasis(DEFAULT_MAX_SH_ORDER)
-,mSphHarmFunc()
-{
+    mSHBasis.reset(new Math::SH::RealSymDescoteauxBasis(DEFAULT_NB_COEFFS));
     genUnitSphere();
 }
 
@@ -34,9 +26,10 @@ Sphere::Sphere(unsigned int resolution,
 :mResolution(resolution)
 ,mIndices()
 ,mPoints()
-,mSHBasis(Math::SH::Utils::OrderFromNbCoeffs(nbSHCoeffs))
+,mSHBasis()
 ,mSphHarmFunc()
 {
+    mSHBasis.reset(new Math::SH::RealSymDescoteauxBasis(nbSHCoeffs));
     genUnitSphere();
 }
 
@@ -67,13 +60,10 @@ void Sphere::addPoint(float theta, float phi, float r)
 {
     const glm::vec3 vecCartesian = convertToCartesian(theta, phi, r);
     mPoints.push_back(glm::vec4(vecCartesian.x, vecCartesian.y, vecCartesian.z, 1.0f));
-    // evaluate SH function for all l, m up to MAX_SH_ORDER
-    for(int l = 0; l <= mSHBasis.GetMaxOrder(); l += 2)
+    const std::vector<float> shFuncs = mSHBasis->at(theta, phi);
+    for(float f : shFuncs)
     {
-        for(int m = -l; m <= l; ++m)
-        {
-            mSphHarmFunc.push_back(mSHBasis.at(l, m, theta, phi));
-        }
+        mSphHarmFunc.push_back(f);
     }
 }
 

--- a/Engine/src/spherical_harmonic.cpp
+++ b/Engine/src/spherical_harmonic.cpp
@@ -5,8 +5,6 @@
 
 namespace Slicer
 {
-namespace Math
-{
 namespace SH
 {
 double legendre(int l, int m, double x)
@@ -19,14 +17,14 @@ double legendre(int l, int m, double x)
     return val;
 }
 
-RealSymDescoteauxBasis::RealSymDescoteauxBasis(unsigned int nbCoeffs)
+DescoteauxBasis::DescoteauxBasis(unsigned int nbCoeffs)
 :mScaling()
 {
     mMaxOrder = getOrderFromNbCoeffs(nbCoeffs, &mFullBasis);
     computeScaling();
 }
 
-size_t RealSymDescoteauxBasis::J(unsigned int l, int m) const
+size_t DescoteauxBasis::J(unsigned int l, int m) const
 {
     if(mFullBasis)
     {
@@ -35,7 +33,7 @@ size_t RealSymDescoteauxBasis::J(unsigned int l, int m) const
     return l * (l + 1) / 2 + m;
 }
 
-size_t RealSymDescoteauxBasis::numCoeffs() const
+size_t DescoteauxBasis::numCoeffs() const
 {
     if(mFullBasis)
     {
@@ -44,7 +42,7 @@ size_t RealSymDescoteauxBasis::numCoeffs() const
     return (mMaxOrder + 1) * (mMaxOrder + 2) / 2;
 }
 
-void RealSymDescoteauxBasis::computeScaling()
+void DescoteauxBasis::computeScaling()
 {
     const size_t nCoeffs = numCoeffs();
     mScaling.resize(nCoeffs);
@@ -62,7 +60,7 @@ void RealSymDescoteauxBasis::computeScaling()
     }
 }
 
-float RealSymDescoteauxBasis::at(unsigned int l, int m, float theta, float phi) const
+float DescoteauxBasis::at(unsigned int l, int m, float theta, float phi) const
 {
     if(l > mMaxOrder || (l % 2 != 0 && !mFullBasis))
     {
@@ -80,7 +78,7 @@ float RealSymDescoteauxBasis::at(unsigned int l, int m, float theta, float phi) 
     }
 }
 
-std::vector<float> RealSymDescoteauxBasis::at(float theta, float phi) const
+std::vector<float> DescoteauxBasis::at(float theta, float phi) const
 {
     std::vector<float> shFuncs;
     for(int l = 0; l <= mMaxOrder; l += mFullBasis ? 1 : 2)
@@ -93,14 +91,14 @@ std::vector<float> RealSymDescoteauxBasis::at(float theta, float phi) const
     return shFuncs;
 }
 
-std::complex<float> RealSymDescoteauxBasis::computeSHFunc(unsigned int l, int m, float theta, float phi) const
+std::complex<float> DescoteauxBasis::computeSHFunc(unsigned int l, int m, float theta, float phi) const
 {
     const float r = mScaling[J(l, m)] * legendre(l, m, cos(theta));
     std::complex<float> sh = std::polar(r, m * phi);
     return sh;
 }
 
-std::vector<float> RealSymDescoteauxBasis::GetOrderList() const
+std::vector<float> DescoteauxBasis::GetOrderList() const
 {
     std::vector<float> orders;
     for(int l = 0; l <= mMaxOrder; l += mFullBasis? 1:2)
@@ -113,7 +111,7 @@ std::vector<float> RealSymDescoteauxBasis::GetOrderList() const
     return orders;
 }
 
-unsigned int RealSymDescoteauxBasis::getOrderFromNbCoeffs(unsigned int nbCoeffs,
+unsigned int DescoteauxBasis::getOrderFromNbCoeffs(unsigned int nbCoeffs,
                                                           bool* fullBasis) const
 {
     const float& floatEpsilon = std::numeric_limits<float>::epsilon();
@@ -140,5 +138,4 @@ unsigned int RealSymDescoteauxBasis::getOrderFromNbCoeffs(unsigned int nbCoeffs,
     throw std::runtime_error("Invalid number of coefficients.");
 }
 } // namespace SH
-} // namespace Math
 } // namespace Slicer

--- a/Engine/src/spherical_harmonic.cpp
+++ b/Engine/src/spherical_harmonic.cpp
@@ -111,8 +111,7 @@ std::vector<float> DescoteauxBasis::GetOrderList() const
     return orders;
 }
 
-unsigned int DescoteauxBasis::getOrderFromNbCoeffs(unsigned int nbCoeffs,
-                                                          bool* fullBasis) const
+unsigned int DescoteauxBasis::getOrderFromNbCoeffs(unsigned int nbCoeffs, bool* fullBasis) const
 {
     const float& floatEpsilon = std::numeric_limits<float>::epsilon();
     const float symOrder = (-3.0 + sqrt(1.0 + 8.0 * nbCoeffs)) / 2.0;

--- a/Engine/src/spherical_harmonic.cpp
+++ b/Engine/src/spherical_harmonic.cpp
@@ -13,31 +13,34 @@ double legendre(int l, int m, double x)
 {
     double val = pow(-1.0, m) * std::assoc_legendre(l, abs(m), x);
     if(m < 0)
+    {
         val *= pow(-1.0f, m) * factorial(l - m) / factorial(l + m);
+    }
     return val;
 }
 
-RealSymDescoteauxBasis::RealSymDescoteauxBasis()
-:mMaxOrder(8)
-,mScaling()
+RealSymDescoteauxBasis::RealSymDescoteauxBasis(unsigned int nbCoeffs)
+:mScaling()
 {
-    computeScaling();
-}
-
-RealSymDescoteauxBasis::RealSymDescoteauxBasis(unsigned int maxOrder)
-:mMaxOrder(maxOrder)
-,mScaling()
-{
+    mMaxOrder = getOrderFromNbCoeffs(nbCoeffs, &mFullBasis);
     computeScaling();
 }
 
 size_t RealSymDescoteauxBasis::J(unsigned int l, int m) const
 {
+    if(mFullBasis)
+    {
+        return l * (l + 1) + m;
+    }
     return l * (l + 1) / 2 + m;
 }
 
 size_t RealSymDescoteauxBasis::numCoeffs() const
 {
+    if(mFullBasis)
+    {
+        return (mMaxOrder + 1) * (mMaxOrder + 1);
+    }
     return (mMaxOrder + 1) * (mMaxOrder + 2) / 2;
 }
 
@@ -45,7 +48,7 @@ void RealSymDescoteauxBasis::computeScaling()
 {
     const size_t nCoeffs = numCoeffs();
     mScaling.resize(nCoeffs);
-    for(int l = 0; l <= mMaxOrder; l += 2)
+    for(int l = 0; l <= mMaxOrder; l += mFullBasis ? 1 : 2)
     {
         for(int m = -l; m <= l; ++m)
         {
@@ -61,7 +64,7 @@ void RealSymDescoteauxBasis::computeScaling()
 
 float RealSymDescoteauxBasis::at(unsigned int l, int m, float theta, float phi) const
 {
-    if(l > mMaxOrder || l % 2 != 0)
+    if(l > mMaxOrder || (l % 2 != 0 && !mFullBasis))
     {
         throw std::runtime_error("Invalid order.");
     }
@@ -77,11 +80,64 @@ float RealSymDescoteauxBasis::at(unsigned int l, int m, float theta, float phi) 
     }
 }
 
+std::vector<float> RealSymDescoteauxBasis::at(float theta, float phi) const
+{
+    std::vector<float> shFuncs;
+    for(int l = 0; l <= mMaxOrder; l += mFullBasis ? 1 : 2)
+    {
+        for(int m = -l; m <= l; ++m)
+        {
+            shFuncs.push_back(at(l, m, theta, phi));
+        }
+    }
+    return shFuncs;
+}
+
 std::complex<float> RealSymDescoteauxBasis::computeSHFunc(unsigned int l, int m, float theta, float phi) const
 {
-    float r = mScaling[J(l, m)] * legendre(l, m, cos(theta));
+    const float r = mScaling[J(l, m)] * legendre(l, m, cos(theta));
     std::complex<float> sh = std::polar(r, m * phi);
     return sh;
+}
+
+std::vector<float> RealSymDescoteauxBasis::GetOrderList() const
+{
+    std::vector<float> orders;
+    for(int l = 0; l <= mMaxOrder; l += mFullBasis? 1:2)
+    {
+        for(int m = -l; m <= l; ++m)
+        {
+            orders.push_back(l);
+        }
+    }
+    return orders;
+}
+
+unsigned int RealSymDescoteauxBasis::getOrderFromNbCoeffs(unsigned int nbCoeffs,
+                                                          bool* fullBasis) const
+{
+    const float& floatEpsilon = std::numeric_limits<float>::epsilon();
+    const float symOrder = (-3.0 + sqrt(1.0 + 8.0 * nbCoeffs)) / 2.0;
+    if((std::trunc(symOrder) >= (symOrder - floatEpsilon)) &&
+       (std::trunc(symOrder) <= (symOrder + floatEpsilon)))
+    {
+        if(fullBasis != nullptr)
+        {
+            *fullBasis = false;
+        }
+        return static_cast<unsigned int>(symOrder);
+    }
+    const float fullOrder = sqrt((float)nbCoeffs) - 1.0;
+    if((std::trunc(fullOrder) >= (fullOrder - floatEpsilon)) &&
+       (std::trunc(fullOrder) <= (fullOrder + floatEpsilon)))
+    {
+        if(fullBasis != nullptr)
+        {
+            *fullBasis = true;
+        }
+        return static_cast<unsigned int>(fullOrder);
+    }
+    throw std::runtime_error("Invalid number of coefficients.");
 }
 } // namespace SH
 } // namespace Math


### PR DESCRIPTION
Full SH support. Auto-detect the type (full vs symmetric) of the spherical harmonics basis from the number of SH coefficients of the input volume. Enables visualization of asymmetric signals on the sphere :smile: 

Closes #11 